### PR TITLE
Use CLOCK_MONOTONIC for background thread sleep to prevent clock rollback stalls

### DIFF
--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -189,11 +189,17 @@ background_thread_sleep(
 	}
 	info->npages_to_purge_new = 0;
 
-	struct timeval tv;
-	/* Specific clock required by timedwait. */
-	gettimeofday(&tv, NULL);
 	nstime_t before_sleep;
+#if defined(JEMALLOC_HAVE_CLOCK_MONOTONIC_COARSE) || defined(JEMALLOC_HAVE_CLOCK_MONOTONIC)
+	/* Use monotonic clock to match the condvar attribute (set in init). */
+	struct timespec ts_before;
+	clock_gettime(CLOCK_MONOTONIC, &ts_before);
+	nstime_init2(&before_sleep, ts_before.tv_sec, ts_before.tv_nsec);
+#else
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
 	nstime_init2(&before_sleep, tv.tv_sec, tv.tv_usec * 1000);
+#endif
 
 	int ret;
 	if (interval == BACKGROUND_THREAD_INDEFINITE_SLEEP) {
@@ -225,9 +231,16 @@ background_thread_sleep(
 		assert(ret == ETIMEDOUT || ret == 0);
 	}
 	if (config_stats) {
-		gettimeofday(&tv, NULL);
 		nstime_t after_sleep;
+#if defined(JEMALLOC_HAVE_CLOCK_MONOTONIC_COARSE) || defined(JEMALLOC_HAVE_CLOCK_MONOTONIC)
+		struct timespec ts_after;
+		clock_gettime(CLOCK_MONOTONIC, &ts_after);
+		nstime_init2(&after_sleep, ts_after.tv_sec, ts_after.tv_nsec);
+#else
+		struct timeval tv;
+		gettimeofday(&tv, NULL);
 		nstime_init2(&after_sleep, tv.tv_sec, tv.tv_usec * 1000);
+#endif
 		if (nstime_compare(&after_sleep, &before_sleep) > 0) {
 			nstime_subtract(&after_sleep, &before_sleep);
 			nstime_add(&info->tot_sleep_time, &after_sleep);
@@ -741,7 +754,15 @@ background_thread_postfork_child(tsdn_t *tsdn) {
 		background_thread_info_t *info = &background_thread_info[i];
 		malloc_mutex_lock(tsdn, &info->mtx);
 		info->state = background_thread_stopped;
+#if defined(JEMALLOC_HAVE_CLOCK_MONOTONIC_COARSE) || defined(JEMALLOC_HAVE_CLOCK_MONOTONIC)
+		pthread_condattr_t cond_attr;
+		pthread_condattr_init(&cond_attr);
+		pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);
+		int ret = pthread_cond_init(&info->cond, &cond_attr);
+		pthread_condattr_destroy(&cond_attr);
+#else
 		int ret = pthread_cond_init(&info->cond, NULL);
+#endif
 		assert(ret == 0);
 		background_thread_info_init(tsdn, info);
 		malloc_mutex_unlock(tsdn, &info->mtx);
@@ -859,9 +880,22 @@ background_thread_boot1(tsdn_t *tsdn, base_t *base) {
 		        malloc_mutex_address_ordered)) {
 			return true;
 		}
+#if defined(JEMALLOC_HAVE_CLOCK_MONOTONIC_COARSE) || defined(JEMALLOC_HAVE_CLOCK_MONOTONIC)
+		{
+			pthread_condattr_t cond_attr;
+			pthread_condattr_init(&cond_attr);
+			pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);
+			if (pthread_cond_init(&info->cond, &cond_attr)) {
+				pthread_condattr_destroy(&cond_attr);
+				return true;
+			}
+			pthread_condattr_destroy(&cond_attr);
+		}
+#else
 		if (pthread_cond_init(&info->cond, NULL)) {
 			return true;
 		}
+#endif
 		malloc_mutex_lock(tsdn, &info->mtx);
 		info->state = background_thread_stopped;
 		background_thread_info_init(tsdn, info);

--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -740,8 +740,9 @@ background_thread_postfork_child(tsdn_t *tsdn) {
 #if defined(JEMALLOC_HAVE_CLOCK_MONOTONIC_COARSE) || defined(JEMALLOC_HAVE_CLOCK_MONOTONIC)
 		int ret;
 		pthread_condattr_t cond_attr;
-		pthread_condattr_init(&cond_attr);
-		if (pthread_condattr_setclock(&cond_attr,
+		if (pthread_condattr_init(&cond_attr)) {
+			ret = pthread_cond_init(&info->cond, NULL);
+		} else if (pthread_condattr_setclock(&cond_attr,
 		    CLOCK_MONOTONIC)) {
 			/*
 			 * Fall back to default (CLOCK_REALTIME)
@@ -877,7 +878,9 @@ background_thread_boot1(tsdn_t *tsdn, base_t *base) {
 #if defined(JEMALLOC_HAVE_CLOCK_MONOTONIC_COARSE) || defined(JEMALLOC_HAVE_CLOCK_MONOTONIC)
 		{
 			pthread_condattr_t cond_attr;
-			pthread_condattr_init(&cond_attr);
+			if (pthread_condattr_init(&cond_attr)) {
+				return true;
+			}
 			if (pthread_condattr_setclock(&cond_attr,
 			    CLOCK_MONOTONIC)) {
 				pthread_condattr_destroy(&cond_attr);

--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -190,16 +190,7 @@ background_thread_sleep(
 	info->npages_to_purge_new = 0;
 
 	nstime_t before_sleep;
-#if defined(JEMALLOC_HAVE_CLOCK_MONOTONIC_COARSE) || defined(JEMALLOC_HAVE_CLOCK_MONOTONIC)
-	/* Use monotonic clock to match the condvar attribute (set in init). */
-	struct timespec ts_before;
-	clock_gettime(CLOCK_MONOTONIC, &ts_before);
-	nstime_init2(&before_sleep, ts_before.tv_sec, ts_before.tv_nsec);
-#else
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-	nstime_init2(&before_sleep, tv.tv_sec, tv.tv_usec * 1000);
-#endif
+	nstime_init_update(&before_sleep);
 
 	int ret;
 	if (interval == BACKGROUND_THREAD_INDEFINITE_SLEEP) {
@@ -232,15 +223,7 @@ background_thread_sleep(
 	}
 	if (config_stats) {
 		nstime_t after_sleep;
-#if defined(JEMALLOC_HAVE_CLOCK_MONOTONIC_COARSE) || defined(JEMALLOC_HAVE_CLOCK_MONOTONIC)
-		struct timespec ts_after;
-		clock_gettime(CLOCK_MONOTONIC, &ts_after);
-		nstime_init2(&after_sleep, ts_after.tv_sec, ts_after.tv_nsec);
-#else
-		struct timeval tv;
-		gettimeofday(&tv, NULL);
-		nstime_init2(&after_sleep, tv.tv_sec, tv.tv_usec * 1000);
-#endif
+		nstime_init_update(&after_sleep);
 		if (nstime_compare(&after_sleep, &before_sleep) > 0) {
 			nstime_subtract(&after_sleep, &before_sleep);
 			nstime_add(&info->tot_sleep_time, &after_sleep);
@@ -755,11 +738,22 @@ background_thread_postfork_child(tsdn_t *tsdn) {
 		malloc_mutex_lock(tsdn, &info->mtx);
 		info->state = background_thread_stopped;
 #if defined(JEMALLOC_HAVE_CLOCK_MONOTONIC_COARSE) || defined(JEMALLOC_HAVE_CLOCK_MONOTONIC)
+		int ret;
 		pthread_condattr_t cond_attr;
 		pthread_condattr_init(&cond_attr);
-		pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);
-		int ret = pthread_cond_init(&info->cond, &cond_attr);
-		pthread_condattr_destroy(&cond_attr);
+		if (pthread_condattr_setclock(&cond_attr,
+		    CLOCK_MONOTONIC)) {
+			/*
+			 * Fall back to default (CLOCK_REALTIME)
+			 * attributes if setclock fails.
+			 */
+			pthread_condattr_destroy(&cond_attr);
+			ret = pthread_cond_init(&info->cond, NULL);
+		} else {
+			ret = pthread_cond_init(&info->cond,
+			    &cond_attr);
+			pthread_condattr_destroy(&cond_attr);
+		}
 #else
 		int ret = pthread_cond_init(&info->cond, NULL);
 #endif
@@ -884,7 +878,11 @@ background_thread_boot1(tsdn_t *tsdn, base_t *base) {
 		{
 			pthread_condattr_t cond_attr;
 			pthread_condattr_init(&cond_attr);
-			pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);
+			if (pthread_condattr_setclock(&cond_attr,
+			    CLOCK_MONOTONIC)) {
+				pthread_condattr_destroy(&cond_attr);
+				return true;
+			}
 			if (pthread_cond_init(&info->cond, &cond_attr)) {
 				pthread_condattr_destroy(&cond_attr);
 				return true;


### PR DESCRIPTION
`background_thread_sleep()` computes the `pthread_cond_timedwait` deadline from `gettimeofday()` (CLOCK_REALTIME). If the wall clock jumps backward (NTP correction, VM
snapshot, leap second), the deadline ends up far in the future and the background thread stops purging dirty pages — potentially for hours or days.

This was observed in production where NTP corrections caused unbounded RSS growth due to the background thread stalling.

## Fix

- Switch deadline computation to `clock_gettime(CLOCK_MONOTONIC)`
- Set `CLOCK_MONOTONIC` on the condvar via `pthread_condattr_setclock` at both init sites (`background_thread_boot1` and `background_thread_postfork_child`)
- Platforms without `CLOCK_MONOTONIC` retain the original `gettimeofday` fallback