### PR TITLE
Allow resuming per-CPU arena selection via thread.arena

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -264,6 +264,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/pack.c \
 	$(srcroot)test/unit/pages.c \
 	$(srcroot)test/unit/peak.c \
+	$(srcroot)test/unit/percpu_arena_resume.c \
 	$(srcroot)test/unit/ph.c \
 	$(srcroot)test/unit/prng.c \
 	$(srcroot)test/unit/prof_accum.c \

--- a/include/jemalloc/internal/jemalloc_internal_inlines_a.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_a.h
@@ -19,9 +19,17 @@ malloc_getcpu(void) {
 #elif defined(JEMALLOC_HAVE_SCHED_GETCPU)
 	return (malloc_cpuid_t)sched_getcpu();
 #elif defined(__APPLE__)
-	/* No sched_getcpu() on macOS; read the CPU number like _os_cpu_number(), see
+	/*
+	 * No sched_getcpu() on macOS; read the CPU number like _os_cpu_number()
+	 * does, from the low 12 bits of tpidr_el0 (arm64) or the IDT base (x86).
+	 * The 0xfff mask is xnu's __TPIDR_CPU_NUM_MASK, kept in sync with
+	 * _os_cpu_number in libsyscall/os/tsd.h (the kernel counterpart is
+	 * MACHDEP_TPIDR_CPUNUM_MASK in osfmk/arm64/machine_machdep.h):
 	 * https://github.com/apple-oss-distributions/xnu/blob/main/libsyscall/os/tsd.h
-	 * (it is no longer in tpidrro_el0's low bits on Apple Silicon). */
+	 * This requires macOS 12+: on macOS 11 and earlier arm64 kept the CPU
+	 * number in tpidrro_el0's low 3 bits instead, so it would be misread here.
+	 * Those releases are retired by Apple, so only the current layout is handled.
+	 */
 #  if defined(__aarch64__)
 	uint64_t cpu;
 	__asm__ __volatile__("mrs %0, tpidr_el0" : "=r"(cpu));

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -2294,11 +2294,20 @@ thread_arena_ctl(tsd_t *tsd, const size_t *mib, size_t miblen, void *oldp,
 		    && PERCPU_ARENA_ENABLED(opt_percpu_arena)) {
 			if (newind < percpu_arena_ind_limit(opt_percpu_arena)) {
 				/*
-				 * If perCPU arena is enabled, thread_arena
-				 * control is not allowed for the auto arena
-				 * range.
+				 * If perCPU arena is enabled, setting
+				 * thread.arena to an arena in the auto range
+				 * means "resume automatic per-CPU selection"
+				 * rather than pinning to a specific per-CPU
+				 * arena. This lets a caller that temporarily
+				 * switched to a manually managed arena (e.g. a
+				 * scoped guard) hand the thread back to per-CPU
+				 * management. It is otherwise impossible: a
+				 * thread bound to a manual arena is never
+				 * reclaimed by percpu (see arena_choose_impl),
+				 * so without this it would stay pinned forever.
 				 */
-				ret = EPERM;
+				percpu_arena_update(tsd, percpu_arena_choose());
+				ret = 0;
 				goto label_return;
 			}
 		}

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -546,12 +546,17 @@ TEST_BEGIN(test_thread_arena) {
 		    0, "Unexpected mallctl() failure");
 		new_arena_ind = percpu_arena_ind_limit(opt_percpu_arena) - 1;
 		if (old_arena_ind != new_arena_ind) {
+			/*
+			 * Setting thread.arena to an index within the per-CPU
+			 * range resumes automatic per-CPU selection rather than
+			 * failing (see test/unit/percpu_arena_resume.c).
+			 */
 			expect_d_eq(
 			    mallctl("thread.arena", (void *)&old_arena_ind, &sz,
 			        (void *)&new_arena_ind, sizeof(unsigned)),
-			    EPERM,
-			    "thread.arena ctl "
-			    "should not be allowed with percpu arena");
+			    0,
+			    "thread.arena within the per-CPU range should "
+			    "resume per-CPU selection");
 		}
 	}
 }

--- a/test/unit/percpu_arena_resume.c
+++ b/test/unit/percpu_arena_resume.c
@@ -1,0 +1,74 @@
+#include "test/jemalloc_test.h"
+
+/*
+ * When percpu_arena is enabled a thread is bound to a manually created arena
+ * (an index at or above the per-CPU auto range) to route a bounded region of
+ * work to a dedicated arena, then handed back to automatic per-CPU selection.
+ *
+ * Setting thread.arena to an index within the per-CPU auto range is the signal
+ * to resume per-CPU management. Without it a thread bound to a manual arena is
+ * never reclaimed by percpu (see arena_choose_impl), so it would stay pinned to
+ * the manual arena forever and its later allocations would land there instead
+ * of following the CPU.
+ */
+TEST_BEGIN(test_thread_arena_resume_percpu) {
+	test_skip_if(!have_percpu_arena
+	    || !PERCPU_ARENA_ENABLED(opt_percpu_arena));
+
+	unsigned limit = percpu_arena_ind_limit(opt_percpu_arena);
+
+	/* Force the thread to be bound to its current CPU's arena. */
+	void *p = mallocx(1, 0);
+	expect_ptr_not_null(p, "Unexpected mallocx() failure");
+
+	unsigned cur;
+	size_t sz = sizeof(cur);
+	expect_d_eq(mallctl("thread.arena", (void *)&cur, &sz, NULL, 0), 0,
+	    "Unexpected mallctl() failure");
+	expect_u_lt(cur, limit,
+	    "Thread should start bound to a per-CPU (auto) arena");
+
+	/* Create a dedicated arena, which is always outside the auto range. */
+	unsigned manual;
+	sz = sizeof(manual);
+	expect_d_eq(mallctl("arenas.create", (void *)&manual, &sz, NULL, 0), 0,
+	    "Unexpected arenas.create() failure");
+	expect_u_ge(manual, limit,
+	    "A manually created arena must be outside the per-CPU range");
+
+	/* Binding to a manual arena is allowed and takes effect. */
+	unsigned old;
+	sz = sizeof(old);
+	expect_d_eq(mallctl("thread.arena", (void *)&old, &sz, (void *)&manual,
+	    sizeof(manual)), 0,
+	    "Binding to a manual arena should be allowed under percpu");
+	sz = sizeof(cur);
+	expect_d_eq(mallctl("thread.arena", (void *)&cur, &sz, NULL, 0), 0,
+	    "Unexpected mallctl() failure");
+	expect_u_eq(cur, manual, "Thread should be bound to the manual arena");
+
+	/*
+	 * Setting thread.arena to an index in the per-CPU range resumes
+	 * automatic per-CPU selection instead of returning EPERM.
+	 */
+	unsigned resume = 0;
+	expect_d_eq(mallctl("thread.arena", NULL, NULL, (void *)&resume,
+	    sizeof(resume)), 0,
+	    "Setting thread.arena within the per-CPU range should resume "
+	    "per-CPU selection, not fail");
+
+	sz = sizeof(cur);
+	expect_d_eq(mallctl("thread.arena", (void *)&cur, &sz, NULL, 0), 0,
+	    "Unexpected mallctl() failure");
+	expect_u_lt(cur, limit,
+	    "Thread should be back under per-CPU management after resuming");
+
+	dallocx(p, 0);
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_thread_arena_resume_percpu);
+}

--- a/test/unit/percpu_arena_resume.c
+++ b/test/unit/percpu_arena_resume.c
@@ -1,69 +1,76 @@
 #include "test/jemalloc_test.h"
 
 /*
- * When percpu_arena is enabled a thread is bound to a manually created arena
- * (an index at or above the per-CPU auto range) to route a bounded region of
- * work to a dedicated arena, then handed back to automatic per-CPU selection.
- *
- * Setting thread.arena to an index within the per-CPU auto range is the signal
- * to resume per-CPU management. Without it a thread bound to a manual arena is
- * never reclaimed by percpu (see arena_choose_impl), so it would stay pinned to
- * the manual arena forever and its later allocations would land there instead
- * of following the CPU.
+ * Under percpu_arena, binding a thread to a manual arena (an index at or above
+ * the per-CPU auto range) is one-way: percpu never reclaims it (see
+ * arena_choose_impl). Setting thread.arena back to an index in the auto range
+ * resumes per-CPU selection instead of failing with EPERM.
  */
 TEST_BEGIN(test_thread_arena_resume_percpu) {
 	test_skip_if(!have_percpu_arena
 	    || !PERCPU_ARENA_ENABLED(opt_percpu_arena));
 
 	unsigned limit = percpu_arena_ind_limit(opt_percpu_arena);
+	/* Bypass the tcache so every allocation and free hits the arena. */
+	const int flags = MALLOCX_TCACHE_NONE;
 
-	/* Force the thread to be bound to its current CPU's arena. */
-	void *p = mallocx(1, 0);
-	expect_ptr_not_null(p, "Unexpected mallocx() failure");
+	void *warm = mallocx(1, 0);
+	expect_ptr_not_null(warm, "Unexpected mallocx() failure");
+	dallocx(warm, 0);
 
 	unsigned cur;
 	size_t sz = sizeof(cur);
 	expect_d_eq(mallctl("thread.arena", (void *)&cur, &sz, NULL, 0), 0,
 	    "Unexpected mallctl() failure");
-	expect_u_lt(cur, limit,
-	    "Thread should start bound to a per-CPU (auto) arena");
+	expect_u_lt(cur, limit, "Thread should start on a per-CPU arena");
 
-	/* Create a dedicated arena, which is always outside the auto range. */
 	unsigned manual;
 	sz = sizeof(manual);
 	expect_d_eq(mallctl("arenas.create", (void *)&manual, &sz, NULL, 0), 0,
 	    "Unexpected arenas.create() failure");
-	expect_u_ge(manual, limit,
-	    "A manually created arena must be outside the per-CPU range");
+	expect_u_ge(manual, limit, "A manual arena is outside the per-CPU range");
 
-	/* Binding to a manual arena is allowed and takes effect. */
 	unsigned old;
 	sz = sizeof(old);
 	expect_d_eq(mallctl("thread.arena", (void *)&old, &sz, (void *)&manual,
-	    sizeof(manual)), 0,
-	    "Binding to a manual arena should be allowed under percpu");
+	    sizeof(manual)), 0, "Binding to a manual arena should be allowed");
 	sz = sizeof(cur);
 	expect_d_eq(mallctl("thread.arena", (void *)&cur, &sz, NULL, 0), 0,
 	    "Unexpected mallctl() failure");
 	expect_u_eq(cur, manual, "Thread should be bound to the manual arena");
 
-	/*
-	 * Setting thread.arena to an index in the per-CPU range resumes
-	 * automatic per-CPU selection instead of returning EPERM.
-	 */
+	void *p_manual = mallocx(1024, flags);
+	expect_ptr_not_null(p_manual, "Unexpected mallocx() failure");
+	unsigned found;
+	sz = sizeof(found);
+	expect_d_eq(mallctl("arenas.lookup", (void *)&found, &sz,
+	    (void *)&p_manual, sizeof(p_manual)), 0,
+	    "Unexpected arenas.lookup() failure");
+	expect_u_eq(found, manual, "Allocation should come from the manual arena");
+
+	void *scratch = mallocx(1024, flags);
+	expect_ptr_not_null(scratch, "Unexpected mallocx() failure");
+	dallocx(scratch, flags);
+
 	unsigned resume = 0;
 	expect_d_eq(mallctl("thread.arena", NULL, NULL, (void *)&resume,
-	    sizeof(resume)), 0,
-	    "Setting thread.arena within the per-CPU range should resume "
-	    "per-CPU selection, not fail");
-
+	    sizeof(resume)), 0, "Should resume per-CPU selection, not fail");
 	sz = sizeof(cur);
 	expect_d_eq(mallctl("thread.arena", (void *)&cur, &sz, NULL, 0), 0,
 	    "Unexpected mallctl() failure");
-	expect_u_lt(cur, limit,
-	    "Thread should be back under per-CPU management after resuming");
+	expect_u_lt(cur, limit, "Thread should be back on a per-CPU arena");
 
-	dallocx(p, 0);
+	void *p_percpu = mallocx(1024, flags);
+	expect_ptr_not_null(p_percpu, "Unexpected mallocx() failure");
+	sz = sizeof(found);
+	expect_d_eq(mallctl("arenas.lookup", (void *)&found, &sz,
+	    (void *)&p_percpu, sizeof(p_percpu)), 0,
+	    "Unexpected arenas.lookup() failure");
+	expect_u_lt(found, limit, "Allocation should come from a per-CPU arena");
+	dallocx(p_percpu, flags);
+
+	/* Free the manual-arena region while bound to a different arena. */
+	dallocx(p_manual, flags);
 }
 TEST_END
 

--- a/test/unit/percpu_arena_resume.sh
+++ b/test/unit/percpu_arena_resume.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export MALLOC_CONF="percpu_arena:percpu"


### PR DESCRIPTION
## Problem

With `percpu_arena` enabled, `thread.arena` control is one-directional. A thread can be bound to a manually created arena (an index at or above the per-CPU auto range), for example to route a bounded region of work to a dedicated, long-lived arena, but there is no way back: `thread_arena_ctl` returns `EPERM` for any index within the auto range, and `arena_choose_impl` only re-selects a per-CPU arena for threads whose current arena is already in that range. So once a thread touches a manual arena it stays pinned there forever, and all its later allocations land there instead of following the CPU.

This blocks the pattern "use per-CPU arenas for general allocation, temporarily switch to a dedicated arena for specific work, then hand the thread back to per-CPU management." It is exactly what ClickHouse needs for a dedicated `MergeTree` metadata arena (see ClickHouse/ClickHouse#109490): without a way to resume, every worker thread that ever writes part metadata gets permanently pinned to the metadata arena and dumps all its later allocations there, defeating both per-CPU locality and the point of the dedicated arena.

## Change

Treat setting `thread.arena` to an index within the per-CPU range as a request to *resume* automatic per-CPU selection: hand the thread back to percpu management (rebinding it to the current CPU's arena via `percpu_arena_update`) and return `0`, instead of `EPERM`. Binding to a manual arena (index at or above the auto range) is unchanged.

The requested index is advisory: under `percpu` the thread is governed by its current CPU, so it resumes on the current CPU's arena regardless of the value passed. This is migration-correct. If the thread moved CPUs between switching to the manual arena and resuming, it lands on the arena for the CPU it is actually running on.

## Tests

- New `test/unit/percpu_arena_resume` (with a `.sh` forcing `percpu_arena:percpu`) covers the manual-arena to resume round trip and asserts the thread returns to the per-CPU range; it `test_skip_if`s when percpu is disabled.
- `test_thread_arena` in `test/unit/mallctl.c` previously asserted the `EPERM`; updated to assert the resume now succeeds.

This branch is based on current `dev`. It also carries a follow-up to ClickHouse/jemalloc#8 (the macOS `malloc_getcpu` fix): a block-comment style change and documenting the macOS 12+ requirement, which were requested during upstream review. It is included here only to keep the fork in sync.

Upstream PR: https://github.com/jemalloc/jemalloc/pull/2957