### PR TITLE
Add fragmentation profiling records to heap dumps

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -273,6 +273,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/prof_hook.c \
 	$(srcroot)test/unit/prof_idump.c \
 	$(srcroot)test/unit/prof_log.c \
+	$(srcroot)test/unit/prof_frag.c \
 	$(srcroot)test/unit/prof_mdump.c \
 	$(srcroot)test/unit/prof_recent.c \
 	$(srcroot)test/unit/prof_reset.c \

--- a/bin/jefrag.py
+++ b/bin/jefrag.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Fragmentation report from a jemalloc heap dump.
+
+Consumes a heap profile produced by prof.dump (heap_v2 format) that contains
+the fragmentation records emitted by jemalloc:
+
+  f: <age_ns> <request_size> <usize> <szind> <arena_ind> <thr_uid>
+      -- one per live sampled allocation, listed under its "@ <pc>..." stack
+  frag_util: <arena_ind> <binind> <reg_size> <slab_size> <nregs> <n_shards>
+      <curslabs> <curregs> <nonfull_slabs>
+      -- one per (arena, small size class)
+
+Ground-truth slab waste per (arena, size class) comes from frag_util; the
+sampled records statistically attribute that waste to the call stacks that
+keep old allocations alive in the class.  Sampling is byte-weighted, so each
+record is unbiased into an estimated object count with the standard Poisson
+factor 1 / (1 - exp(-usize / sample_interval)).
+
+Note: curregs counts regions cached in tcaches as allocated, so waste is a
+lower bound estimate ("waste" regions may partially be tcache-cached).
+
+Outputs:
+  --report (default)  top-pinner table per fragmented (arena, size class)
+  --collapsed         folded stacks weighted by attributed waste bytes, for
+                      flamegraph.pl / speedscope
+"""
+
+import argparse
+import bisect
+import math
+import re
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+
+PAGE_HINT = 4096
+
+
+def parse_dump(f):
+    sample_interval = None
+    stacks = {}  # stack (tuple of pc ints) -> list of records
+    utils = {}  # (arena, binind) -> dict
+    maps = []  # raw MAPPED_LIBRARIES lines
+    cur_stack = None
+    in_maps = False
+
+    for line in f:
+        line = line.rstrip("\n")
+        if in_maps:
+            maps.append(line)
+            continue
+        if line.startswith("MAPPED_LIBRARIES:"):
+            in_maps = True
+            continue
+        stripped = line.strip()
+        if sample_interval is None and stripped.startswith("heap_v2/"):
+            sample_interval = int(stripped.split("/", 1)[1].split()[0])
+            continue
+        if stripped.startswith("@ "):
+            cur_stack = tuple(int(pc, 16) for pc in stripped[2:].split())
+            stacks.setdefault(cur_stack, [])
+            continue
+        if stripped.startswith("f: "):
+            fields = stripped[3:].split()
+            if len(fields) != 6 or cur_stack is None:
+                continue
+            rec = {
+                "age_ns": int(fields[0]),
+                "size": int(fields[1]),
+                "usize": int(fields[2]),
+                "szind": int(fields[3]),
+                "arena": int(fields[4]),
+                "thr_uid": int(fields[5]),
+            }
+            stacks[cur_stack].append(rec)
+            continue
+        if stripped.startswith("frag_util: "):
+            fields = stripped[len("frag_util: "):].split()
+            if len(fields) != 9:
+                continue
+            (arena, binind, reg_size, slab_size, nregs, n_shards, curslabs,
+                curregs, nonfull_slabs) = (int(x) for x in fields)
+            utils[(arena, binind)] = {
+                "reg_size": reg_size,
+                "slab_size": slab_size,
+                "nregs": nregs,
+                "n_shards": n_shards,
+                "curslabs": curslabs,
+                "curregs": curregs,
+                "nonfull_slabs": nonfull_slabs,
+                "waste": curslabs * slab_size - curregs * reg_size,
+            }
+            continue
+
+    if sample_interval is None:
+        sys.exit("error: input is not a heap_v2 jemalloc profile")
+    return sample_interval, stacks, utils, maps
+
+
+def unbias(usize, sample_interval):
+    """Estimated number of allocations one sampled allocation stands for."""
+    ratio = usize / sample_interval
+    if ratio > 30:
+        return 1.0
+    return 1.0 / (1.0 - math.exp(-ratio))
+
+
+class Symbolizer:
+    def __init__(self, maps_lines, enabled):
+        self.enabled = enabled
+        self.cache = {}
+        # Executable mappings: (start, end, base, path).
+        self.mappings = []
+        if not enabled:
+            return
+        for line in maps_lines:
+            # <start>-<end> <perms> <offset> <dev> <inode> <path>
+            parts = line.split()
+            if len(parts) < 6 or "x" not in parts[1]:
+                continue
+            path = parts[5]
+            if not path.startswith("/"):
+                continue
+            start, end = (int(x, 16) for x in parts[0].split("-"))
+            offset = int(parts[2], 16)
+            self.mappings.append((start, end, start - offset, path))
+        self.mappings.sort()
+        self.starts = [m[0] for m in self.mappings]
+        self.tool = shutil.which("llvm-symbolizer") or shutil.which(
+            "addr2line")
+        if self.tool is None:
+            self.enabled = False
+
+    def _lookup_mapping(self, pc):
+        i = bisect.bisect_right(self.starts, pc) - 1
+        if i >= 0:
+            start, end, base, path = self.mappings[i]
+            if pc < end:
+                return base, path
+        return None, None
+
+    def resolve_many(self, pcs):
+        todo = defaultdict(list)  # path -> [(pc, file-relative addr)]
+        for pc in pcs:
+            if pc in self.cache:
+                continue
+            self.cache[pc] = "0x%x" % pc
+            if not self.enabled:
+                continue
+            base, path = self._lookup_mapping(pc)
+            if path is not None:
+                # The return address points past the call site.
+                todo[path].append((pc, pc - base - 1))
+        for path, addrs in todo.items():
+            self._symbolize_file(path, addrs)
+
+    def _symbolize_file(self, path, addrs):
+        if "llvm-symbolizer" in self.tool:
+            cmd = [self.tool, "--obj=" + path, "--functions=linkage",
+                "--no-inlines"]
+        else:
+            cmd = [self.tool, "-f", "-e", path]
+        try:
+            out = subprocess.run(cmd,
+                input="".join("0x%x\n" % a for _, a in addrs),
+                capture_output=True, text=True, timeout=60).stdout
+        except Exception:
+            return
+        # Both tools print the function name as the first of (up to) two
+        # lines per address; llvm-symbolizer separates entries with a blank
+        # line.
+        names = []
+        expect_name = True
+        for line in out.splitlines():
+            if not line.strip():
+                expect_name = True
+                continue
+            if expect_name:
+                names.append(line.strip())
+                expect_name = False
+        for (pc, _), name in zip(addrs, names):
+            if name and name not in ("??", "<invalid>"):
+                self.cache[pc] = name
+
+    def name(self, pc):
+        return self.cache.get(pc, "0x%x" % pc)
+
+
+def attribute(sample_interval, stacks, utils, min_age_ns):
+    """Return ({(arena, szind): [(stack, est_objs)]}, {(arena, szind): total})."""
+    per_class = defaultdict(lambda: defaultdict(float))
+    for stack, recs in stacks.items():
+        for rec in recs:
+            if rec["age_ns"] < min_age_ns:
+                continue
+            key = (rec["arena"], rec["szind"])
+            if key not in utils:
+                continue  # Large size class: no slab waste to attribute.
+            per_class[key][stack] += unbias(rec["usize"], sample_interval)
+    totals = {
+        key: sum(shares.values()) for key, shares in per_class.items()
+    }
+    return per_class, totals
+
+
+def fmt_bytes(n):
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if abs(n) < 4096 or unit == "GiB":
+            return "%.1f %s" % (n, unit) if unit != "B" else "%d B" % n
+        n /= 1024.0
+    return "%d" % n
+
+
+# Leading allocator-internal frames to strip (same idea as jeprof's
+# --ignore defaults for jemalloc).
+_INTERNAL_FRAME = re.compile(
+    r"^(je_|jet_|_?prof_|imalloc|malloc_default"
+    r"|(m|c|re|d|sd)allocx?$|free$|posix_memalign$|aligned_alloc$"
+    r"|operator new)")
+
+
+def user_frames(stack, sym, depth):
+    frames = [sym.name(pc) for pc in stack[:depth]]
+    while len(frames) > 1 and _INTERNAL_FRAME.match(frames[0]):
+        frames.pop(0)
+    return frames
+
+
+def fmt_stack(stack, sym, depth):
+    return ";".join(user_frames(stack, sym, depth))
+
+
+def report(args, sample_interval, stacks, utils, sym):
+    min_age_ns = int(args.min_age * 1e9)
+    per_class, totals = attribute(sample_interval, stacks, utils, min_age_ns)
+
+    classes = sorted(
+        utils.items(), key=lambda kv: kv[1]["waste"], reverse=True)
+    total_waste = sum(u["waste"] for _, u in utils.items())
+    attributed_waste = 0.0
+
+    print("sample_interval: %d bytes" % sample_interval)
+    print("min_age: %g s" % args.min_age)
+    print("total slab waste: %s (upper bound; tcache-cached regions count"
+        " as allocated)" % fmt_bytes(total_waste))
+    print()
+
+    shown = 0
+    for (arena, binind), u in classes:
+        if u["waste"] < args.min_waste:
+            continue
+        if args.top_classes and shown >= args.top_classes:
+            break
+        shown += 1
+        availregs = u["curslabs"] * u["nregs"]
+        util_pct = 100.0 * u["curregs"] / availregs if availregs else 100.0
+        print("arena %d size-class %d (reg_size %d): waste %s, util %.1f%%,"
+            " curslabs %d, curregs %d" % (arena, binind,
+                u["reg_size"], fmt_bytes(u["waste"]), util_pct, u["curslabs"],
+                u["curregs"]))
+        key = (arena, binind)
+        shares = per_class.get(key)
+        if not shares:
+            print("  (no sampled allocation of this class is older than"
+                " min_age: waste unattributed; consider lowering"
+                " lg_prof_sample or min_age)")
+            print()
+            continue
+        total = totals[key]
+        ranked = sorted(shares.items(), key=lambda kv: kv[1], reverse=True)
+        for stack, est in ranked[: args.top_stacks]:
+            share = est / total
+            attributed_waste += u["waste"] * share
+            print("  %5.1f%% (~%s, est %.0f old objects) %s"
+                % (100.0 * share, fmt_bytes(u["waste"] * share), est,
+                    fmt_stack(stack, sym, args.depth)))
+        print()
+
+    print("attributed waste: %s of %s"
+        % (fmt_bytes(attributed_waste), fmt_bytes(total_waste)))
+
+
+def collapsed(args, sample_interval, stacks, utils, sym):
+    min_age_ns = int(args.min_age * 1e9)
+    per_class, totals = attribute(sample_interval, stacks, utils, min_age_ns)
+
+    weights = defaultdict(float)  # stack -> attributed waste bytes
+    for key, shares in per_class.items():
+        waste = utils[key]["waste"]
+        total = totals[key]
+        if total <= 0:
+            continue
+        for stack, est in shares.items():
+            weights[stack] += waste * est / total
+
+    for stack, weight in sorted(weights.items(), key=lambda kv: -kv[1]):
+        if weight < 1:
+            continue
+        # Flamegraph convention: root first.
+        frames = list(reversed(user_frames(stack, sym, args.depth)))
+        print("%s %d" % (";".join(frames), round(weight)))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("dump", help="heap dump file (- for stdin)")
+    parser.add_argument("--collapsed", action="store_true",
+        help="emit folded stacks for flamegraphs instead of the report")
+    parser.add_argument("--min-age", type=float, default=60.0,
+        help="only allocations older than this many seconds pin slabs"
+        " (default: 60)")
+    parser.add_argument("--min-waste", type=int, default=PAGE_HINT,
+        help="hide size classes wasting less than this many bytes")
+    parser.add_argument("--top-stacks", type=int, default=5,
+        help="stacks shown per size class in the report (default: 5)")
+    parser.add_argument("--top-classes", type=int, default=0,
+        help="max size classes shown, 0 = all")
+    parser.add_argument("--depth", type=int, default=16,
+        help="max stack frames used (default: 16)")
+    parser.add_argument("--no-symbolize", action="store_true",
+        help="print raw addresses")
+    args = parser.parse_args()
+
+    f = sys.stdin if args.dump == "-" else open(args.dump)
+    with f:
+        sample_interval, stacks, utils, maps = parse_dump(f)
+
+    sym = Symbolizer(maps, not args.no_symbolize)
+    pcs = set()
+    for stack, recs in stacks.items():
+        if recs:
+            pcs.update(stack[: args.depth])
+    sym.resolve_many(pcs)
+
+    if args.collapsed:
+        collapsed(args, sample_interval, stacks, utils, sym)
+    else:
+        report(args, sample_interval, stacks, utils, sym)
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/jemalloc.xml.in
+++ b/doc/jemalloc.xml.in
@@ -2485,7 +2485,31 @@ struct extent_hooks_s {
         where <literal>&lt;prefix&gt;</literal> is controlled by the
         <link linkend="opt.prof_prefix"><mallctl>opt.prof_prefix</mallctl></link>
         and <link linkend="prof.prefix"><mallctl>prof.prefix</mallctl></link>
-        options.</para></listitem>
+        options.</para>
+
+        <para>In addition to the standard
+        <literal>heap_v2</literal> records, dumps contain fragmentation
+        profiling records (ignored by <command>jeprof</command>, consumed by
+        <command>jefrag.py</command>).  Each live sampled allocation
+        produces, under its backtrace, a line <programlisting language="C"><![CDATA[
+  f: <age_ns> <request_size> <usize> <szind> <arena_ind> <thr_uid>]]></programlisting>
+        where age is relative to the dump time (using the
+        <mallctl>opt.prof_time_resolution</mallctl> clock), and the size
+        class/arena are those the allocation would
+        occupy had it not been sampled.  Each (arena, small size class) pair
+        with at least one slab produces a line <programlisting language="C"><![CDATA[
+  frag_util: <arena_ind> <binind> <reg_size> <slab_size> <nregs> <n_shards>
+      <curslabs> <curregs> <nonfull_slabs>]]></programlisting>
+        from which slab waste is <literal>curslabs * slab_size - curregs *
+        reg_size</literal>; note that regions cached in thread caches count
+        as allocated.  Correlating the ages of live sampled allocations with
+        per-class waste identifies call sites whose long-lived allocations
+        pin mostly-empty slabs (fragmentation).  Since sampling is
+        byte-weighted, small size classes need a small enough
+        <link
+        linkend="opt.lg_prof_sample"><mallctl>opt.lg_prof_sample</mallctl></link>
+        to be represented; each sampled allocation occupies at least one
+        page.</para></listitem>
       </varlistentry>
 
       <varlistentry id="prof.prefix">

--- a/include/jemalloc/internal/edata.h
+++ b/include/jemalloc/internal/edata.h
@@ -29,6 +29,9 @@
  */
 #define ESET_ENUMERATE_MAX_NUM 32
 
+/* Forward declaration; needed by the linkage in e_prof_info_s. */
+typedef struct edata_s edata_t;
+
 enum extent_state_e {
 	extent_state_active = 0,
 	extent_state_dirty = 1,
@@ -66,6 +69,15 @@ struct e_prof_info_s {
 	 * Protected by prof_recent_alloc_mtx.
 	 */
 	atomic_p_t e_prof_recent_alloc;
+	/*
+	 * Linkage into the owning gctx's list of live sampled allocations
+	 * (gctx->frag_objs).  Both fields are protected by the owning gctx's
+	 * lock; the owning gctx is reachable via e_prof_tctx while
+	 * e_prof_frag_tracked is true (the tctx cannot be destroyed before
+	 * the allocation is untracked).
+	 */
+	ql_elm(edata_t) e_prof_frag_link;
+	bool e_prof_frag_tracked;
 };
 typedef struct e_prof_info_s e_prof_info_t;
 
@@ -93,7 +105,6 @@ struct edata_cmp_summary_s {
 };
 
 /* Extent (span of pages).  Use accessor functions for e_* fields. */
-typedef struct edata_s edata_t;
 ph_structs(edata_avail, edata_t, ESET_ENUMERATE_MAX_NUM);
 ph_structs(edata_heap, edata_t, ESET_ENUMERATE_MAX_NUM);
 struct edata_s {
@@ -276,6 +287,7 @@ struct edata_s {
 
 TYPED_LIST(edata_list_active, edata_t, ql_link_active)
 TYPED_LIST(edata_list_inactive, edata_t, ql_link_inactive)
+TYPED_LIST(edata_list_frag, edata_t, e_prof_info.e_prof_frag_link)
 
 static inline unsigned
 edata_arena_ind_get(const edata_t *edata) {
@@ -642,6 +654,16 @@ edata_prof_recent_alloc_set_dont_call_directly(
     edata_t *edata, prof_recent_t *recent_alloc) {
 	atomic_store_p(&edata->e_prof_info.e_prof_recent_alloc, recent_alloc,
 	    ATOMIC_RELAXED);
+}
+
+static inline bool
+edata_prof_frag_tracked_get(const edata_t *edata) {
+	return edata->e_prof_info.e_prof_frag_tracked;
+}
+
+static inline void
+edata_prof_frag_tracked_set(edata_t *edata, bool tracked) {
+	edata->e_prof_info.e_prof_frag_tracked = tracked;
 }
 
 static inline bool

--- a/include/jemalloc/internal/prof_data.h
+++ b/include/jemalloc/internal/prof_data.h
@@ -28,6 +28,8 @@ prof_tdata_t *prof_tdata_init_impl(tsd_t *tsd, uint64_t thr_uid,
 void          prof_tdata_detach(tsd_t *tsd, prof_tdata_t *tdata);
 void          prof_reset(tsd_t *tsd, size_t lg_sample);
 void          prof_tctx_try_destroy(tsd_t *tsd, prof_tctx_t *tctx);
+void          prof_frag_track(tsd_t *tsd, edata_t *edata, prof_tctx_t *tctx);
+void          prof_frag_untrack(tsd_t *tsd, edata_t *edata, prof_tctx_t *tctx);
 
 /* Used in unit tests. */
 size_t prof_tdata_count(void);

--- a/include/jemalloc/internal/prof_structs.h
+++ b/include/jemalloc/internal/prof_structs.h
@@ -137,6 +137,12 @@ struct prof_gctx_s {
 	/* Temporary storage for summation during dump. */
 	prof_cnt_t cnt_summed;
 
+	/*
+	 * List of live sampled allocations whose backtrace resolved to this
+	 * gctx, linked through edata's e_prof_frag_link.  Protected by lock.
+	 */
+	edata_list_frag_t frag_objs;
+
 	/* Associated backtrace. */
 	prof_bt_t bt;
 

--- a/src/large.c
+++ b/src/large.c
@@ -5,6 +5,7 @@
 #include "jemalloc/internal/emap.h"
 #include "jemalloc/internal/extent_mmap.h"
 #include "jemalloc/internal/mutex.h"
+#include "jemalloc/internal/prof_data.h"
 #include "jemalloc/internal/prof_recent.h"
 #include "jemalloc/internal/util.h"
 
@@ -294,6 +295,7 @@ large_prof_info_get(
 		    &prof_info->alloc_time, edata_prof_alloc_time_get(edata));
 		prof_info->alloc_size = edata_prof_alloc_size_get(edata);
 		if (reset_recent) {
+			prof_frag_untrack(tsd, edata, alloc_tctx);
 			/*
 			 * Reset the pointer on the recent allocation record,
 			 * so that this allocation is recorded as released.
@@ -320,5 +322,11 @@ large_prof_info_set(edata_t *edata, prof_tctx_t *tctx, size_t size) {
 	edata_prof_alloc_time_set(edata, &t);
 	edata_prof_alloc_size_set(edata, size);
 	edata_prof_recent_alloc_init(edata);
+	/*
+	 * The flag may hold garbage from a previous (slab) use of this edata;
+	 * it must be cleared before the tctx is published below, which is what
+	 * makes the allocation reachable by prof_frag_untrack().
+	 */
+	edata_prof_frag_tracked_set(edata, false);
 	large_prof_tctx_set(edata, tctx);
 }

--- a/src/prof.c
+++ b/src/prof.c
@@ -124,6 +124,7 @@ prof_malloc_sample_object(
 	edata_t *edata = emap_edata_lookup(
 	    tsd_tsdn(tsd), &arena_emap_global, ptr);
 	prof_info_set(tsd, edata, tctx, size);
+	prof_frag_track(tsd, edata, tctx);
 
 	szind_t szind = sz_size2index(usize);
 

--- a/src/prof_data.c
+++ b/src/prof_data.c
@@ -204,6 +204,7 @@ prof_gctx_create(tsdn_t *tsdn, prof_bt_t *bt) {
 	 */
 	gctx->nlimbo = 1;
 	tctx_tree_new(&gctx->tctxs);
+	edata_list_frag_init(&gctx->frag_objs);
 	/* Duplicate bt. */
 	memcpy(gctx->vec, bt->vec, bt->len * sizeof(void *));
 	gctx->bt.vec = gctx->vec;
@@ -226,6 +227,12 @@ prof_gctx_try_destroy(tsd_t *tsd, prof_tdata_t *tdata_self, prof_gctx_t *gctx) {
 	malloc_mutex_lock(tsd_tsdn(tsd), gctx->lock);
 	assert(gctx->nlimbo != 0);
 	if (tctx_tree_empty(&gctx->tctxs) && gctx->nlimbo == 1) {
+		/*
+		 * No live tctx implies no live sampled allocation attributed
+		 * to this gctx (each such allocation holds a curobjs count on
+		 * its tctx until untracked).
+		 */
+		assert(edata_list_frag_empty(&gctx->frag_objs));
 		/* Remove gctx from bt2gctx. */
 		if (ckh_remove(tsd, &bt2gctx, &gctx->bt, NULL, NULL)) {
 			not_reached();
@@ -243,6 +250,44 @@ prof_gctx_try_destroy(tsd_t *tsd, prof_tdata_t *tdata_self, prof_gctx_t *gctx) {
 		malloc_mutex_unlock(tsd_tsdn(tsd), gctx->lock);
 		prof_leave(tsd, tdata_self);
 	}
+}
+
+/*
+ * Track/untrack a live sampled allocation on its gctx's frag_objs list, so
+ * that heap dumps can enumerate live sampled allocations (fragmentation
+ * profiling).  Called with no locks held: track from
+ * prof_malloc_sample_object() while tctx->prepared still pins the tctx;
+ * untrack from the prof_info_get_and_reset_recent() sever point, which on
+ * every deallocation path precedes the curobjs decrement in
+ * prof_free_sampled_object() -- so in both cases the tctx (hence gctx) is
+ * guaranteed alive.
+ */
+void
+prof_frag_track(tsd_t *tsd, edata_t *edata, prof_tctx_t *tctx) {
+	prof_gctx_t *gctx = tctx->gctx;
+
+	malloc_mutex_lock(tsd_tsdn(tsd), gctx->lock);
+	assert(!edata_prof_frag_tracked_get(edata));
+	edata_list_frag_append(&gctx->frag_objs, edata);
+	edata_prof_frag_tracked_set(edata, true);
+	malloc_mutex_unlock(tsd_tsdn(tsd), gctx->lock);
+}
+
+void
+prof_frag_untrack(tsd_t *tsd, edata_t *edata, prof_tctx_t *tctx) {
+	prof_gctx_t *gctx = tctx->gctx;
+
+	malloc_mutex_lock(tsd_tsdn(tsd), gctx->lock);
+	/*
+	 * Not necessarily tracked: if an in-place reallocation severed the
+	 * allocation but then failed (OOM), the allocation stays live yet
+	 * untracked, and its eventual deallocation severs it a second time.
+	 */
+	if (edata_prof_frag_tracked_get(edata)) {
+		edata_list_frag_remove(&gctx->frag_objs, edata);
+		edata_prof_frag_tracked_set(edata, false);
+	}
+	malloc_mutex_unlock(tsd_tsdn(tsd), gctx->lock);
 }
 
 static bool
@@ -725,6 +770,8 @@ struct prof_dump_iter_arg_s {
 	tsdn_t     *tsdn;
 	write_cb_t *prof_dump_write;
 	void       *cbopaque;
+	/* Dump-time timestamp for computing live sampled allocation ages. */
+	nstime_t now;
 };
 
 static prof_tctx_t *
@@ -981,6 +1028,38 @@ prof_dump_gctx(prof_dump_iter_arg_t *arg, prof_gctx_t *gctx,
 	arg->prof_dump_write(arg->cbopaque, "\n");
 
 	tctx_tree_iter(&gctx->tctxs, NULL, prof_tctx_dump_iter, arg);
+
+	/*
+	 * One record per live sampled allocation attributed to this gctx, for
+	 * fragmentation profiling (ignored by jeprof):
+	 *   f: <age_ns> <request_size> <usize> <szind> <arena_ind> <thr_uid>
+	 * An allocation on frag_objs cannot be concurrently deallocated (its
+	 * sever point takes gctx->lock), and its tctx is pinned by the
+	 * allocation's curobjs count, so all reads below are stable.
+	 */
+	for (edata_t *edata = edata_list_frag_first(&gctx->frag_objs);
+	    edata != NULL;
+	    edata = edata_list_frag_next(&gctx->frag_objs, edata)) {
+		const nstime_t *alloc_time = edata_prof_alloc_time_get(edata);
+		nstime_t age;
+		if (nstime_compare(&arg->now, alloc_time) > 0) {
+			nstime_copy(&age, &arg->now);
+			nstime_subtract(&age, alloc_time);
+		} else {
+			/*
+			 * Sampled after this dump's timestamp was taken (or
+			 * within the prof clock resolution).
+			 */
+			nstime_init_zero(&age);
+		}
+		prof_tctx_t *tctx = edata_prof_tctx_get(edata);
+		assert(prof_tctx_is_valid(tctx));
+		prof_dump_printf(arg->prof_dump_write, arg->cbopaque,
+		    "  f: %" FMTu64 " %zu %zu %u %u %" FMTu64 "\n",
+		    nstime_ns(&age), edata_prof_alloc_size_get(edata),
+		    edata_usize_get(edata), (unsigned)edata_szind_get(edata),
+		    edata_arena_ind_get(edata), tctx->thr_uid);
+	}
 }
 
 /*
@@ -1038,6 +1117,49 @@ prof_gctx_dump_iter(prof_gctx_tree_t *gctxs, prof_gctx_t *gctx, void *opaque) {
 	return NULL;
 }
 
+/*
+ * Per-(arena, bin) slab utilization snapshot, for fragmentation profiling
+ * (ignored by jeprof):
+ *   frag_util: <arena_ind> <binind> <reg_size> <slab_size> <nregs> <n_shards>
+ *       <curslabs> <curregs> <nonfull_slabs>
+ * Wasted memory per line is curslabs * slab_size - curregs * reg_size.
+ */
+static void
+prof_dump_frag_util(prof_dump_iter_arg_t *arg) {
+	if (!config_stats) {
+		/* curslabs/curregs/nonfull_slabs are not maintained. */
+		return;
+	}
+	for (unsigned i = 0; i < narenas_total_get(); i++) {
+		arena_t *arena = arena_get(arg->tsdn, i, false);
+		if (arena == NULL) {
+			continue;
+		}
+		for (szind_t j = 0; j < SC_NBINS; j++) {
+			const bin_info_t *info = &bin_infos[j];
+			size_t curslabs = 0;
+			size_t curregs = 0;
+			size_t nonfull_slabs = 0;
+			for (unsigned k = 0; k < info->n_shards; k++) {
+				bin_t *bin = arena_get_bin(arena, j, k);
+				malloc_mutex_lock(arg->tsdn, &bin->lock);
+				curslabs += bin->stats.curslabs;
+				curregs += bin->stats.curregs;
+				nonfull_slabs += bin->stats.nonfull_slabs;
+				malloc_mutex_unlock(arg->tsdn, &bin->lock);
+			}
+			if (curslabs == 0) {
+				continue;
+			}
+			prof_dump_printf(arg->prof_dump_write, arg->cbopaque,
+			    "frag_util: %u %u %zu %zu %u %u %zu %zu %zu\n",
+			    i, (unsigned)j, info->reg_size, info->slab_size,
+			    info->nregs, info->n_shards, curslabs, curregs,
+			    nonfull_slabs);
+		}
+	}
+}
+
 static void
 prof_dump_prep(tsd_t *tsd, prof_tdata_t *tdata, prof_cnt_t *cnt_all,
     size_t *leak_ngctx, prof_gctx_tree_t *gctxs) {
@@ -1089,9 +1211,11 @@ prof_dump_impl(tsd_t *tsd, write_cb_t *prof_dump_write, void *cbopaque,
 	prof_gctx_tree_t gctxs;
 	prof_dump_prep(tsd, tdata, &cnt_all, &leak_ngctx, &gctxs);
 	prof_dump_iter_arg_t prof_dump_iter_arg = {
-	    tsd_tsdn(tsd), prof_dump_write, cbopaque};
+	    tsd_tsdn(tsd), prof_dump_write, cbopaque, NSTIME_ZERO_INITIALIZER};
+	nstime_prof_init_update(&prof_dump_iter_arg.now);
 	prof_dump_header(&prof_dump_iter_arg, &cnt_all);
 	gctx_tree_iter(&gctxs, NULL, prof_gctx_dump_iter, &prof_dump_iter_arg);
+	prof_dump_frag_util(&prof_dump_iter_arg);
 	prof_gctx_finish(tsd, &gctxs);
 	if (leakcheck) {
 		prof_leakcheck(&cnt_all, leak_ngctx);

--- a/test/unit/prof_frag.c
+++ b/test/unit/prof_frag.c
@@ -1,0 +1,433 @@
+#include "test/jemalloc_test.h"
+
+#include "jemalloc/internal/prof_sys.h"
+
+/*
+ * The tests below capture heap dumps (produced with lg_prof_sample:0, i.e.
+ * every allocation sampled) via the JET-mutable prof_dump_{open,write}_file
+ * hooks, and then parse the fragmentation records:
+ *   f: <age_ns> <request_size> <usize> <szind> <arena_ind> <thr_uid>
+ *   frag_util: <arena_ind> <binind> <reg_size> <slab_size> <nregs> <n_shards>
+ *       <curslabs> <curregs> <nonfull_slabs>
+ * Records of interest are identified by uncommon request sizes, so that
+ * allocations made by the test harness itself do not interfere.
+ */
+
+static const char *test_filename = "test_filename";
+
+#define DUMP_BUF_SIZE (16u << 20)
+static char   dump_buf[DUMP_BUF_SIZE];
+static size_t dump_len;
+static bool   dump_discard;
+
+static prof_dump_open_file_t  *open_file_orig;
+static prof_dump_write_file_t *write_file_orig;
+
+static int
+prof_dump_open_file_intercept(const char *filename, int mode) {
+	int fd = open("/dev/null", O_WRONLY);
+	assert_d_ne(fd, -1, "Unexpected open() failure");
+	return fd;
+}
+
+static ssize_t
+prof_dump_write_file_intercept(int fd, const void *s, size_t len) {
+	if (!dump_discard) {
+		assert_zu_le(dump_len + len, DUMP_BUF_SIZE,
+		    "Dump capture buffer overflow");
+		memcpy(&dump_buf[dump_len], s, len);
+		dump_len += len;
+	}
+	return (ssize_t)len;
+}
+
+static void
+intercepts_install(void) {
+	open_file_orig = prof_dump_open_file;
+	write_file_orig = prof_dump_write_file;
+	prof_dump_open_file = prof_dump_open_file_intercept;
+	prof_dump_write_file = prof_dump_write_file_intercept;
+}
+
+static void
+intercepts_restore(void) {
+	prof_dump_open_file = open_file_orig;
+	prof_dump_write_file = write_file_orig;
+}
+
+static void
+dump(void) {
+	dump_len = 0;
+	dump_buf[0] = '\0';
+	assert_d_eq(mallctl("prof.dump", NULL, NULL, (void *)&test_filename,
+	                sizeof(test_filename)),
+	    0, "Unexpected mallctl(\"prof.dump\", ...) failure");
+	assert_zu_lt(dump_len, DUMP_BUF_SIZE, "Dump capture buffer overflow");
+	dump_buf[dump_len] = '\0';
+}
+
+typedef struct frag_rec_s {
+	uint64_t age_ns;
+	size_t   size;
+	size_t   usize;
+	unsigned szind;
+	unsigned arena_ind;
+	uint64_t thr_uid;
+} frag_rec_t;
+
+/*
+ * Count "f:" records whose request size is `size`; if last is not NULL, it is
+ * filled with the last matching record.
+ */
+static size_t
+frag_rec_count(size_t size, frag_rec_t *last) {
+	size_t count = 0;
+	for (const char *line = dump_buf; line != NULL;
+	    line = strchr(line, '\n'), line = (line == NULL) ? NULL : line + 1) {
+		frag_rec_t rec;
+		if (sscanf(line, "  f: %" FMTu64 " %zu %zu %u %u %" FMTu64,
+		        &rec.age_ns, &rec.size, &rec.usize, &rec.szind,
+		        &rec.arena_ind, &rec.thr_uid)
+		    != 6) {
+			continue;
+		}
+		if (rec.size != size) {
+			continue;
+		}
+		count++;
+		if (last != NULL) {
+			*last = rec;
+		}
+	}
+	return count;
+}
+
+typedef struct frag_util_rec_s {
+	unsigned arena_ind;
+	unsigned binind;
+	size_t   reg_size;
+	size_t   slab_size;
+	unsigned nregs;
+	unsigned n_shards;
+	size_t   curslabs;
+	size_t   curregs;
+	size_t   nonfull_slabs;
+} frag_util_rec_t;
+
+static bool
+frag_util_rec_find(unsigned arena_ind, unsigned binind, frag_util_rec_t *out) {
+	for (const char *line = dump_buf; line != NULL;
+	    line = strchr(line, '\n'), line = (line == NULL) ? NULL : line + 1) {
+		frag_util_rec_t rec;
+		if (sscanf(line, "frag_util: %u %u %zu %zu %u %u %zu %zu %zu",
+		        &rec.arena_ind, &rec.binind, &rec.reg_size,
+		        &rec.slab_size, &rec.nregs, &rec.n_shards, &rec.curslabs,
+		        &rec.curregs, &rec.nonfull_slabs)
+		    != 9) {
+			continue;
+		}
+		if (rec.arena_ind != arena_ind || rec.binind != binind) {
+			continue;
+		}
+		*out = rec;
+		return true;
+	}
+	return false;
+}
+
+TEST_BEGIN(test_frag_basic) {
+	test_skip_if(!config_prof);
+
+	intercepts_install();
+
+	enum { NALLOCS = 3 };
+	const size_t size_small = 17;    /* Promoted to a page-sized extent. */
+	const size_t size_large = 40033; /* Large size class. */
+	void        *small[NALLOCS];
+	void        *large[NALLOCS];
+
+	for (unsigned i = 0; i < NALLOCS; i++) {
+		small[i] = mallocx(size_small, 0);
+		assert_ptr_not_null(small[i], "Unexpected mallocx() failure");
+		large[i] = mallocx(size_large, 0);
+		assert_ptr_not_null(large[i], "Unexpected mallocx() failure");
+	}
+
+	dump();
+
+	/*
+	 * Zero-initialized because expect macros do not abort: on a count
+	 * mismatch the fields would be read uninitialized otherwise.
+	 */
+	frag_rec_t rec = {0};
+	expect_zu_eq(frag_rec_count(size_small, &rec), NALLOCS,
+	    "Wrong live sampled record count");
+	expect_zu_eq(rec.usize, sz_s2u(size_small),
+	    "Wrong usize in fragmentation record");
+	expect_zu_eq(sz_index2size(rec.szind), rec.usize,
+	    "szind does not match usize");
+	expect_zu_eq(frag_rec_count(size_large, &rec), NALLOCS,
+	    "Wrong live sampled record count");
+	expect_zu_eq(rec.usize, sz_s2u(size_large),
+	    "Wrong usize in fragmentation record");
+
+	/* Free a subset: the corresponding records must disappear. */
+	dallocx(small[0], 0);
+	dallocx(large[0], 0);
+	dallocx(large[1], 0);
+
+	dump();
+	expect_zu_eq(frag_rec_count(size_small, NULL), NALLOCS - 1,
+	    "Records of freed allocations must disappear");
+	expect_zu_eq(frag_rec_count(size_large, NULL), NALLOCS - 2,
+	    "Records of freed allocations must disappear");
+
+	for (unsigned i = 1; i < NALLOCS; i++) {
+		dallocx(small[i], 0);
+	}
+	dallocx(large[2], 0);
+
+	dump();
+	expect_zu_eq(frag_rec_count(size_small, NULL), 0,
+	    "Records of freed allocations must disappear");
+	expect_zu_eq(frag_rec_count(size_large, NULL), 0,
+	    "Records of freed allocations must disappear");
+
+	intercepts_restore();
+}
+TEST_END
+
+TEST_BEGIN(test_frag_age_monotonic) {
+	test_skip_if(!config_prof);
+
+	intercepts_install();
+
+	const size_t size = 30011;
+	void        *p = mallocx(size, 0);
+	assert_ptr_not_null(p, "Unexpected mallocx() failure");
+
+	dump();
+	frag_rec_t first = {0};
+	expect_zu_eq(frag_rec_count(size, &first), 1, "Missing record");
+
+	dump();
+	frag_rec_t second = {0};
+	expect_zu_eq(frag_rec_count(size, &second), 1, "Missing record");
+	expect_u64_ge(second.age_ns, first.age_ns,
+	    "Age must not decrease across dumps");
+
+	dallocx(p, 0);
+	intercepts_restore();
+}
+TEST_END
+
+TEST_BEGIN(test_frag_xallocx_inplace) {
+	test_skip_if(!config_prof);
+
+	intercepts_install();
+
+	const size_t size_old = 5 * PAGE;
+	const size_t size_new = 4 * PAGE;
+
+	void *p = mallocx(size_old, 0);
+	assert_ptr_not_null(p, "Unexpected mallocx() failure");
+
+	dump();
+	expect_zu_eq(frag_rec_count(size_old, NULL), 1, "Missing record");
+	expect_zu_eq(frag_rec_count(size_new, NULL), 0, "Unexpected record");
+
+	/* In-place shrink of a large allocation. */
+	size_t usize = xallocx(p, size_new, 0, 0);
+	expect_zu_eq(usize, size_new, "Unexpected xallocx() result");
+
+	dump();
+	expect_zu_eq(frag_rec_count(size_old, NULL), 0,
+	    "Old record must disappear after in-place reallocation");
+	frag_rec_t rec = {0};
+	expect_zu_eq(frag_rec_count(size_new, &rec), 1,
+	    "In-place reallocation must be tracked exactly once");
+	expect_zu_eq(rec.usize, size_new, "Wrong usize after xallocx()");
+
+	dallocx(p, 0);
+
+	dump();
+	expect_zu_eq(frag_rec_count(size_new, NULL), 0,
+	    "Records of freed allocations must disappear");
+
+	intercepts_restore();
+}
+TEST_END
+
+TEST_BEGIN(test_frag_manual_arena_reset) {
+	test_skip_if(!config_prof);
+
+	intercepts_install();
+
+	unsigned arena_ind;
+	size_t   sz = sizeof(arena_ind);
+	assert_d_eq(
+	    mallctl("arenas.create", (void *)&arena_ind, &sz, NULL, 0), 0,
+	    "Unexpected mallctl(\"arenas.create\", ...) failure");
+
+	const size_t size = 50021;
+	void        *p = mallocx(
+	    size, MALLOCX_ARENA(arena_ind) | MALLOCX_TCACHE_NONE);
+	assert_ptr_not_null(p, "Unexpected mallocx() failure");
+
+	dump();
+	frag_rec_t rec = {0};
+	expect_zu_eq(frag_rec_count(size, &rec), 1, "Missing record");
+	expect_u_eq(rec.arena_ind, arena_ind,
+	    "Record must carry the manual arena index");
+
+	/* arena.<i>.reset frees everything, via the prof_free() path. */
+	char cmd[64];
+	malloc_snprintf(cmd, sizeof(cmd), "arena.%u.reset", arena_ind);
+	assert_d_eq(mallctl(cmd, NULL, NULL, NULL, 0), 0,
+	    "Unexpected mallctl(\"%s\", ...) failure", cmd);
+
+	dump();
+	expect_zu_eq(frag_rec_count(size, NULL), 0,
+	    "Records must disappear after arena reset");
+
+	intercepts_restore();
+}
+TEST_END
+
+TEST_BEGIN(test_frag_util) {
+	test_skip_if(!config_prof);
+	/* frag_util records come from bin stats. */
+	test_skip_if(!config_stats);
+
+	intercepts_install();
+
+	unsigned arena_ind;
+	size_t   sz = sizeof(arena_ind);
+	assert_d_eq(
+	    mallctl("arenas.create", (void *)&arena_ind, &sz, NULL, 0), 0,
+	    "Unexpected mallctl(\"arenas.create\", ...) failure");
+
+	/*
+	 * Slabs can only be populated by unsampled allocations (sampled ones
+	 * are promoted out of slabs), so disable sampling while creating the
+	 * fragmented bin.
+	 */
+	bool prof_active_old;
+	bool active = false;
+	sz = sizeof(prof_active_old);
+	assert_d_eq(mallctl("prof.active", (void *)&prof_active_old, &sz,
+	                (void *)&active, sizeof(active)),
+	    0, "Unexpected mallctl(\"prof.active\", ...) failure");
+
+	const size_t   size = 48;
+	const unsigned binind = (unsigned)sz_size2index(size);
+	const unsigned nregs = bin_infos[binind].nregs;
+	const unsigned nallocs = 2 * nregs;
+	void         **ptrs = malloc(nallocs * sizeof(void *));
+	assert_ptr_not_null(ptrs, "Unexpected malloc() failure");
+	for (unsigned i = 0; i < nallocs; i++) {
+		ptrs[i] = mallocx(
+		    size, MALLOCX_ARENA(arena_ind) | MALLOCX_TCACHE_NONE);
+		assert_ptr_not_null(ptrs[i], "Unexpected mallocx() failure");
+	}
+	/* Free all but one region per slab: maximum fragmentation. */
+	unsigned nleft = 0;
+	for (unsigned i = 0; i < nallocs; i++) {
+		if (i % nregs != 0) {
+			dallocx(ptrs[i], MALLOCX_TCACHE_NONE);
+		} else {
+			nleft++;
+		}
+	}
+
+	active = true;
+	assert_d_eq(mallctl("prof.active", NULL, NULL, (void *)&active,
+	                sizeof(active)),
+	    0, "Unexpected mallctl(\"prof.active\", ...) failure");
+
+	dump();
+
+	frag_util_rec_t rec = {0};
+	expect_true(frag_util_rec_find(arena_ind, binind, &rec),
+	    "Missing frag_util record for the fragmented bin");
+	expect_zu_eq(rec.reg_size, sz_index2size(binind),
+	    "Wrong reg_size in frag_util record");
+	expect_u_eq(rec.nregs, nregs, "Wrong nregs in frag_util record");
+	expect_zu_ge(rec.curslabs, 2, "Expected multiple slabs");
+	expect_zu_ge(rec.curregs, nleft, "curregs below live region count");
+	expect_zu_lt(rec.curregs, rec.curslabs * rec.nregs,
+	    "Expected slab waste (curregs < curslabs * nregs)");
+
+	for (unsigned i = 0; i < nallocs; i += nregs) {
+		dallocx(ptrs[i], MALLOCX_TCACHE_NONE);
+	}
+	free(ptrs);
+
+	/* Restore the original prof.active. */
+	assert_d_eq(mallctl("prof.active", NULL, NULL,
+	                (void *)&prof_active_old, sizeof(prof_active_old)),
+	    0, "Unexpected mallctl(\"prof.active\", ...) failure");
+
+	intercepts_restore();
+}
+TEST_END
+
+#define STRESS_NTHREADS 4
+#define STRESS_NITERS 500
+#define STRESS_NLIVE 8
+
+static atomic_b_t stress_stop;
+
+static void *
+stress_thd(void *arg) {
+	(void)arg;
+	void *live[STRESS_NLIVE] = {NULL};
+	for (unsigned i = 0; i < STRESS_NITERS; i++) {
+		unsigned slot = i % STRESS_NLIVE;
+		if (live[slot] != NULL) {
+			dallocx(live[slot], 0);
+		}
+		/* Mix of small (promoted) and large sampled allocations. */
+		size_t size = (i % 2 == 0) ? (i % 100 + 1) : (PAGE * (i % 8 + 1));
+		live[slot] = mallocx(size, 0);
+		assert_ptr_not_null(live[slot], "Unexpected mallocx() failure");
+	}
+	for (unsigned slot = 0; slot < STRESS_NLIVE; slot++) {
+		if (live[slot] != NULL) {
+			dallocx(live[slot], 0);
+		}
+	}
+	return NULL;
+}
+
+TEST_BEGIN(test_frag_stress) {
+	test_skip_if(!config_prof);
+
+	intercepts_install();
+	dump_discard = true;
+
+	thd_t thds[STRESS_NTHREADS];
+	atomic_store_b(&stress_stop, false, ATOMIC_RELAXED);
+	for (unsigned i = 0; i < STRESS_NTHREADS; i++) {
+		thd_create(&thds[i], stress_thd, NULL);
+	}
+	for (unsigned i = 0; i < 10; i++) {
+		assert_d_eq(mallctl("prof.dump", NULL, NULL,
+		                (void *)&test_filename, sizeof(test_filename)),
+		    0, "Unexpected mallctl(\"prof.dump\", ...) failure");
+	}
+	for (unsigned i = 0; i < STRESS_NTHREADS; i++) {
+		thd_join(thds[i], NULL);
+	}
+
+	dump_discard = false;
+	intercepts_restore();
+}
+TEST_END
+
+int
+main(void) {
+	return test(test_frag_basic, test_frag_age_monotonic,
+	    test_frag_xallocx_inplace, test_frag_manual_arena_reset,
+	    test_frag_util, test_frag_stress);
+}

--- a/test/unit/prof_frag.sh
+++ b/test/unit/prof_frag.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "x${enable_prof}" = "x1" ] ; then
+  export MALLOC_CONF="prof:true,prof_active:true,lg_prof_sample:0"
+fi


### PR DESCRIPTION
Track live sampled allocations on a per-gctx list (in e_prof_info union slack; edata_t size unchanged) under the gctx lock: track in prof_malloc_sample_object(), untrack at the reset_recent sever point. Untrack precedes the curobjs decrement on every dalloc path, so a listed edata always has a live tctx/gctx.  Dumps emit "f:" and "frag_util:" lines (ignored by jeprof); bin/jefrag.py builds the report.

Upstream: https://github.com/jemalloc/jemalloc/pull/2988